### PR TITLE
Correct the casing of the event schema

### DIFF
--- a/doc_source/appconfig-creating-configuration-and-profile-validators.md
+++ b/doc_source/appconfig-creating-configuration-and-profile-validators.md
@@ -32,15 +32,15 @@ AWS AppConfig supports JSON Schema version 4\.X for inline schema\. If your appl
 
 **AWS Lambda Validators**
 
-Lambda function validators must be configured with the following event schema\. AWS AppConfig uses this schema to invoke the Lambda function\. The content is a base64\-encoded string, and the URI is a string\. 
+Lambda function validators must be configured to expect the following event schema\. The content is a base64\-encoded string, and the URI is a string\. 
 
 ```
 {
-    "ApplicationId": "The application Id of the configuration profile being validated", 
-    "ConfigurationProfileId": "The configuration profile Id of the configuration profile being validated",
-    "ConfigurationVersion": "The configuration version of the configuration profile being validated",
-    "Content": "Base64EncodedByteString", 
-    "Uri": "The uri of the configuration"    
+    "applicationId": "The application Id of the configuration profile being validated", 
+    "configurationProfileId": "The configuration profile Id of the configuration profile being validated",
+    "configurationVersion": "The configuration version of the configuration profile being validated",
+    "content": "Base64EncodedByteString", 
+    "uri": "The uri of the configuration"    
 }
 ```
 


### PR DESCRIPTION
It is confusing the document the schema in TitleCase when the schema actually received is in camelCase, so correct. Remove the sentence about how AppConfig invokes this Lambda because this is not relevant to application developers

*Issue #, if available:* I haven't created one

*Description of changes:* Correct the casing of the event schema


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
