### PR TITLE
Appconf: Fix repeated name param in Windows sample

### DIFF
--- a/doc_source/appconfig-creating-deployment-strategy.md
+++ b/doc_source/appconfig-creating-deployment-strategy.md
@@ -98,7 +98,6 @@ The following procedure describes how to use the AWS CLI \(on Linux or Windows\)
      --final-bake-time-in-minutes Amount_of_time_AWS AppConfig_monitors_for_alarms_before_considering_the_deployment_to_be_complete ^
      --growth-factor The_percentage_of_targets_to_receive_a_deployed_configuration_during_each_interval ^
      --growth-type The_linear_or_exponential_algorithm_used_to_define_how_percentage_grows_over_time ^
-     --name A_name_for_the_deployment_strategy ^
      --replicate-to To_save_the_deployment_strategy_to_a_Systems_Manager_(SSM)_document ^
      --tags User_defined_key_value_pair_metadata_of_the_deployment_strategy
    ```


### PR DESCRIPTION
In the Windows code sample request of appconfig-creating-deployment-strategy.md the `--name` parameter was repeated (it's also the first parameter with the exact the same value).
Windows sample now looks like the other 2 samples, the issue is easier to detect by switching tabs (Linux, Windows, Powershell) in https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-creating-deployment-strategy.html as in there when switching to Windows you see this extra line that is not present in the other 2.

*Issue #, if available:*
No issue reported.

*Description of changes:*
Removing the duplicated name parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
